### PR TITLE
bugfix: FreeModbus master and slave concurrent support

### DIFF
--- a/components/freemodbus/port/portother_m.c
+++ b/components/freemodbus/port/portother_m.c
@@ -60,13 +60,13 @@ static UCHAR ucPortMode = 0;
 /* ----------------------- Start implementation -----------------------------*/
 
 UCHAR
-ucMBPortGetMode( void )
+ucMBMasterPortGetMode( void ) // TODO renamed based on EQ-703
 {
     return ucPortMode;
 }
 
 void
-vMBPortSetMode( UCHAR ucMode )
+vMBMasterPortSetMode( UCHAR ucMode ) // TODO renamed based on EQ-703
 {
     ENTER_CRITICAL_SECTION();
     ucPortMode = ucMode;

--- a/components/freemodbus/port/porttimer.c
+++ b/components/freemodbus/port/porttimer.c
@@ -61,8 +61,8 @@
 #define MB_TIMER_DIVIDER        ((TIMER_BASE_CLK / 1000000UL) * MB_DISCR_TIME_US - 1) // divider for 50uS
 #define MB_TIMER_WITH_RELOAD    (1)
 
-static const USHORT usTimerIndex = CONFIG_FMB_TIMER_INDEX; // Modbus Timer index used by stack
-static const USHORT usTimerGroupIndex = CONFIG_FMB_TIMER_GROUP; // Modbus Timer group index used by stack
+static const USHORT usTimerIndex = CONFIG_FMB_TIMER_INDEX + 1; // TODO EQ-716 Modbus Timer index used by stack
+static const USHORT usTimerGroupIndex = CONFIG_FMB_TIMER_GROUP + 1; // TODO EQ-716 Modbus Timer group index used by stack
 
 static timg_dev_t *MB_TG[2] = {&TIMERG0, &TIMERG1};
 

--- a/components/freemodbus/serial_master/port/port_serial_master.h
+++ b/components/freemodbus/serial_master/port/port_serial_master.h
@@ -56,7 +56,7 @@
 PR_BEGIN_EXTERN_C
 #endif /* __cplusplus */
    
-void vMBPortSetMode( UCHAR ucMode );
+void vMBMasterPortSetMode( UCHAR ucMode ); // TODO renamed based on EQ-703
 
 #ifdef __cplusplus
 PR_END_EXTERN_C


### PR DESCRIPTION
bugfix: FreeModbus master and slave concurrent support

Jira: EQ-686
- separated Modbus timers used for master and slave
- workarounded duplicate APIs hen building both slave and master instances.

Signed-off-by: Simon THIEBAUT <simon.thiebaut@zodiac.com>