### PR TITLE
bugfix: workaround failing ISR install for Modbus

### DIFF
--- a/components/freemodbus/port/portserial.c
+++ b/components/freemodbus/port/portserial.c
@@ -246,7 +246,7 @@ BOOL xMBPortSerialInit(UCHAR ucPORT, ULONG ulBaudRate,
             FALSE, "mb config failure, uart_param_config() returned (0x%x).", (uint32_t)xErr);
     // Install UART driver, and get the queue.
     xErr = uart_driver_install(ucUartNumber, MB_SERIAL_BUF_SIZE, MB_SERIAL_BUF_SIZE,
-            MB_QUEUE_LENGTH, &xMbUartQueue, ESP_INTR_FLAG_LEVEL3);
+            MB_QUEUE_LENGTH, &xMbUartQueue, ESP_INTR_FLAG_LOWMED); // TODO EQ-717, ISR might fail to be installed, adding also possible ISR prio 1 and 2
     MB_PORT_CHECK((xErr == ESP_OK), FALSE,
             "mb serial driver failure, uart_driver_install() returned (0x%x).", (uint32_t)xErr);
 #ifndef MB_TIMER_PORT_ENABLED

--- a/components/freemodbus/port/portserial_m.c
+++ b/components/freemodbus/port/portserial_m.c
@@ -241,7 +241,7 @@ BOOL xMBMasterPortSerialInit( UCHAR ucPORT, ULONG ulBaudRate, UCHAR ucDataBits, 
             FALSE, "mb config failure, uart_param_config() returned (0x%x).", (uint32_t)xErr);
     // Install UART driver, and get the queue.
     xErr = uart_driver_install(ucUartNumber, MB_SERIAL_BUF_SIZE, MB_SERIAL_BUF_SIZE,
-            MB_QUEUE_LENGTH, &xMbUartQueue, ESP_INTR_FLAG_LEVEL3);
+            MB_QUEUE_LENGTH, &xMbUartQueue, ESP_INTR_FLAG_LOWMED); // TODO EQ-717, ISR might fail to be installed, adding also possible ISR prio 1 and 2
     MB_PORT_CHECK((xErr == ESP_OK), FALSE,
             "mb serial driver failure, uart_driver_install() returned (0x%x).", (uint32_t)xErr);
     // Set timeout for TOUT interrupt (T3.5 modbus time)


### PR DESCRIPTION
bugfix: workaround failing ISR install for Modbus

Jira: EQ-686
- workarounded ISR failing install due to too restrictive ISR priority requirement (cf. EQ-717 to remind to check possible library updates).

Signed-off-by: Simon THIEBAUT <simon.thiebaut@zodiac.com>