### PR TITLE
Bugfix: ISR modification to avoid panic when using NVS

### DIFF
--- a/components/freemodbus/port/porttimer.c
+++ b/components/freemodbus/port/porttimer.c
@@ -113,7 +113,7 @@ BOOL xMBPortTimersInit(USHORT usTim1Timerout50us)
                     "failure to set alarm failure, timer_set_alarm_value() returned (0x%x).",
                     (uint32_t)xErr);
     // Register ISR for timer
-    xErr = timer_isr_register(usTimerGroupIndex, usTimerIndex, vTimerGroupIsr, NULL, ESP_INTR_FLAG_IRAM, NULL);
+    xErr = timer_isr_register(usTimerGroupIndex, usTimerIndex, vTimerGroupIsr, NULL, ESP_INTR_FLAG_LOWMED, NULL); // TODO EQ-721 ISR causing panic
     MB_PORT_CHECK((xErr == ESP_OK), FALSE,
                     "timer set value failure, timer_isr_register() returned (0x%x).",
                     (uint32_t)xErr);

--- a/components/freemodbus/port/porttimer_m.c
+++ b/components/freemodbus/port/porttimer_m.c
@@ -115,7 +115,7 @@ BOOL xMBMasterPortTimersInit(USHORT usTimeOut50us)
                     (uint32_t)xErr);
     // Register ISR for timer
     xErr = timer_isr_register(usTimerGroupIndex, usTimerIndex,
-                                vTimerGroupIsr, NULL, ESP_INTR_FLAG_IRAM, NULL);
+                                vTimerGroupIsr, NULL, ESP_INTR_FLAG_LOWMED, NULL); // TODO EQ-721 ISR causing panic
     MB_PORT_CHECK((xErr == ESP_OK), FALSE,
                     "timer set value failure, timer_isr_register() returned (0x%x).",
                     (uint32_t)xErr);


### PR DESCRIPTION
Jira: EQ-721

Fix panic when using NVS and modbus communication at the same time, during OTA download as example.

Signed-off-by: Clément Marrast <clement.marrast@zodiac.com>