### PR TITLE
bugfix: Modbus duplicate APIs with both master and slave

### DIFF
--- a/components/freemodbus/port/portother_m.c
+++ b/components/freemodbus/port/portother_m.c
@@ -60,13 +60,13 @@ static UCHAR ucPortMode = 0;
 /* ----------------------- Start implementation -----------------------------*/
 
 UCHAR
-ucMBPortGetMode( void )
+ucMBMasterPortGetMode( void ) // TODO renamed based on EQ-703
 {
     return ucPortMode;
 }
 
 void
-vMBPortSetMode( UCHAR ucMode )
+vMBMasterPortSetMode( UCHAR ucMode ) // TODO renamed based on EQ-703
 {
     ENTER_CRITICAL_SECTION();
     ucPortMode = ucMode;

--- a/components/freemodbus/serial_master/port/port_serial_master.h
+++ b/components/freemodbus/serial_master/port/port_serial_master.h
@@ -56,7 +56,7 @@
 PR_BEGIN_EXTERN_C
 #endif /* __cplusplus */
 
-void vMBPortSetMode( UCHAR ucMode );
+void vMBMasterPortSetMode( UCHAR ucMode ); // TODO renamed based on EQ-703
 
 #ifdef __cplusplus
 PR_END_EXTERN_C


### PR DESCRIPTION
bugfix: Modbus duplicate APIs with both master and slave

Jira: EQ-686
- workarounded duplicate APIs hen building both slave and master instances
- same as commits 848843da5ce7c348c1eecbd4cdf6db2c9aa38a78 and 848843da5ce7c348c1eecbd4cdf6db2c9aa38a78 already merged on previous SDK version.

Signed-off-by: Simon THIEBAUT <simon.thiebaut@zodiac.com>