### PR TITLE
bugfix:  workaround for sporadic E01 that shows up

### DIFF
--- a/components/freemodbus/port/portevent_m.c
+++ b/components/freemodbus/port/portevent_m.c
@@ -122,7 +122,7 @@ xMBMasterPortEventGet( eMBMasterEventType * eEvent)
             MB_EVENT_POLL_MASK,     // The bits within the event group to wait for.
             pdTRUE,                 // Masked bits should be cleared before returning.
             pdFALSE,                // Don't wait for both bits, either bit will do.
-            2100);        // Wait forever for either bit to be set.
+            3100);        // Wait forever for either bit to be set. TODO EQ-907
 
     // Check if poll event is correct
     if (uxBits & MB_EVENT_POLL_MASK) {
@@ -131,7 +131,7 @@ xMBMasterPortEventGet( eMBMasterEventType * eEvent)
     } else {
         vMBMasterSetErrorType(EV_ERROR_RESPOND_TIMEOUT);
         xMBMasterPortEventPost(EV_MASTER_ERROR_PROCESS);
-        ESP_LOGE(MB_PORT_TAG,"%s: Incorrect event triggered.", __func__);
+        //ESP_LOGE(MB_PORT_TAG,"%s: Incorrect event triggered.", __func__); TODO EQ-907
         xEventHappened = FALSE;
     }
     return xEventHappened;

--- a/components/freemodbus/serial_master/modbus_controller/mbc_serial_master.c
+++ b/components/freemodbus/serial_master/modbus_controller/mbc_serial_master.c
@@ -67,7 +67,7 @@ static void modbus_master_task(void *pvParameters)
         // Check if stack started then poll for data
         if (status & MB_EVENT_STACK_STARTED) {
             if(eMBMasterPoll() != MB_ENOERR){
-                ESP_LOGE(MB_MASTER_TAG, "%s: Timeout wait notification ",__FUNCTION__);
+                //ESP_LOGE(MB_MASTER_TAG, "%s: Timeout wait notification ",__FUNCTION__); TODO EQ-907
             }else
             {
             // Allow stack to process data


### PR DESCRIPTION
bugfix:  workaround for sporadic E01 that shows up

Jira: EQ-900
- workarounded E01 that shows up at HMI boot by increasing timer and removing log. Very likely to be a timing issue
- ticket EQ-907 has been created to fix this bug properly.

Signed-off-by: Simon THIEBAUT <simon.thiebaut@zodiac.com>