### PR TITLE
Modbus: fix timer index

### DIFF
--- a/components/freemodbus/port/porttimer_m.c
+++ b/components/freemodbus/port/porttimer_m.c
@@ -57,8 +57,8 @@
 /* ----------------------- Variables ----------------------------------------*/
 static USHORT usT35TimeOut50us;
 
-static const USHORT usTimerIndex = MB_TIMER_INDEX;      // Initialize Modbus Timer index used by stack,
-static const USHORT usTimerGroupIndex = MB_TIMER_GROUP; // Timer group index used by stack
+static const USHORT usTimerIndex = MB_TIMER_INDEX +1;      // Initialize Modbus Timer index used by stack,
+static const USHORT usTimerGroupIndex = MB_TIMER_GROUP +1; // Timer group index used by stack
 static timer_isr_handle_t xTimerIntHandle;              // Timer interrupt handle
 
 /* ----------------------- static functions ---------------------------------*/

--- a/components/freemodbus/port/porttimer_m.c
+++ b/components/freemodbus/port/porttimer_m.c
@@ -51,14 +51,14 @@
 #define MB_TIMER_WITH_RELOAD    (1)
 
 // Timer group and timer number to measure time (configurable in KConfig)
-#define MB_TIMER_INDEX          (CONFIG_FMB_TIMER_INDEX)
-#define MB_TIMER_GROUP          (CONFIG_FMB_TIMER_GROUP)
+#define MB_TIMER_INDEX          (CONFIG_FMB_TIMER_INDEX +1)
+#define MB_TIMER_GROUP          (CONFIG_FMB_TIMER_GROUP +1)
 
 /* ----------------------- Variables ----------------------------------------*/
 static USHORT usT35TimeOut50us;
 
-static const USHORT usTimerIndex = MB_TIMER_INDEX +1;      // Initialize Modbus Timer index used by stack,
-static const USHORT usTimerGroupIndex = MB_TIMER_GROUP +1; // Timer group index used by stack
+static const USHORT usTimerIndex = MB_TIMER_INDEX;      // Initialize Modbus Timer index used by stack,
+static const USHORT usTimerGroupIndex = MB_TIMER_GROUP; // Timer group index used by stack
 static timer_isr_handle_t xTimerIntHandle;              // Timer interrupt handle
 
 /* ----------------------- static functions ---------------------------------*/


### PR DESCRIPTION
JIRA: EQ-978

Use different timer for slave and master

Signed-off-by: Clément Marrast <clement.marrast@zodiac.com>