### PR TITLE
bugfix: Modbus causes assert when destroying stack while requests are ongoing

### DIFF
--- a/components/freemodbus/port/portevent_m.c
+++ b/components/freemodbus/port/portevent_m.c
@@ -281,7 +281,12 @@ eMBMasterReqErrCode eMBMasterWaitRequestFinish( void ) {
         }
     } else {
         ESP_LOGE(MB_PORT_TAG,"%s: Incorrect event or timeout xRecvedEvent = 0x%x", __func__, uxBits);
-        assert(0);
+        // https://github.com/espressif/esp-idf/issues/5275
+        // if a no event is received, that means vMBMasterPortEventClose
+        // has been closed, so event group has been deleted by FreeRTOS, which
+        // triggers the send of 0 value to the event group to unlock this task
+        // waiting on it. For this patch, handles it as a time out without assert.
+        eErrStatus = MB_MRE_TIMEDOUT;
     }
     return eErrStatus;
 }


### PR DESCRIPTION
bugfix: Modbus causes assert when destroying stack while requests are ongoing

Jira: https://github.com/espressif/esp-idf/issues/5275
- patched unexpected event as timeouts rather than causing reset.

Signed-off-by: Simon THIEBAUT <simon.thiebaut@zodiac.com>