### PR TITLE
bugfix: USART function in flashed but called from IRAM

### DIFF
--- a/components/soc/esp32/include/hal/uart_ll.h
+++ b/components/soc/esp32/include/hal/uart_ll.h
@@ -736,10 +736,9 @@ static inline void uart_ll_get_data_bit_num(uart_dev_t *hw, uart_word_length_t *
  *
  * @return True if the state machine is in the IDLE state, otherwise false is returned.
  */
-static inline bool uart_ll_is_tx_idle(uart_dev_t *hw)
+static __attribute__((always_inline)) inline bool uart_ll_is_tx_idle(uart_dev_t *hw)
 {
-    typeof(hw->status) status = hw->status;
-    return ((status.txfifo_cnt == 0) && (status.st_utx_out == 0));
+    return ((hw->status.txfifo_cnt == 0) && (hw->status.st_utx_out == 0));
 }
 
 /**


### PR DESCRIPTION
bugfix: USART function in flashed but called from IRAM

Jira: IDFGH-3775
- forced inlining of USART function uart_ll_is_tx_idle that can be called under ISR context and normal context. With compiler size optimization, this function could be moved to flash even if it was tagged "inline"
- fixed copied from Espressif team proposition.

Signed-off-by: Simon THIEBAUT <simon.thiebaut@zodiac.com>