### PR TITLE
bugfix: unhandled Modbus error causes stack deadlock

### DIFF
--- a/components/freemodbus/modbus/include/mb_m.h
+++ b/components/freemodbus/modbus/include/mb_m.h
@@ -85,7 +85,8 @@ typedef enum
     MB_MRE_REV_DATA,                /*!< receive data error. */
     MB_MRE_TIMEDOUT,                /*!< timeout error occurred. */
     MB_MRE_MASTER_BUSY,             /*!< master is busy now. */
-    MB_MRE_EXE_FUN                  /*!< execute function error. */
+    MB_MRE_EXE_FUN,                 /*!< execute function error. */
+    MB_MRE_SEND_FRAME               /*!< send frame error. */
 } eMBMasterReqErrCode;
 
 /*! \ingroup modbus

--- a/components/freemodbus/modbus/include/mbport.h
+++ b/components/freemodbus/modbus/include/mbport.h
@@ -75,12 +75,14 @@ typedef enum {
     EV_MASTER_ERROR_RESPOND_TIMEOUT = 0x0080,   /*!< Request respond timeout. */
     EV_MASTER_ERROR_RECEIVE_DATA = 0x0100,      /*!< Request receive data error. */
     EV_MASTER_ERROR_EXECUTE_FUNCTION = 0x0200,  /*!< Request execute function error. */
+    EV_MASTER_ERROR_SEND_FRAME = 0x0400,        /*!< Request send frame error. */
 } eMBMasterEventType;
 
 typedef enum {
     EV_ERROR_RESPOND_TIMEOUT,  /*!< Slave respond timeout. */
     EV_ERROR_RECEIVE_DATA,     /*!< Receive frame data erroe. */
     EV_ERROR_EXECUTE_FUNCTION, /*!< Execute function error. */
+    EV_ERROR_SEND_FRAME,       /*!< Send frame error. */
     EV_ERROR_OK                /*!< Data processed. */
 } eMBMasterErrorEventType;
 #endif
@@ -185,6 +187,9 @@ void            vMBMasterErrorCBReceiveData( UCHAR ucDestAddress, const UCHAR* p
 
 void            vMBMasterErrorCBExecuteFunction( UCHAR ucDestAddress, const UCHAR* pucPDUData,
                                                  USHORT ucPDULength );
+
+void            vMBMasterErrorCBSendFrame( UCHAR ucDestAddress, const UCHAR* pucPDUData,
+                                           USHORT ucPDULength);
 
 void            vMBMasterCBRequestSuccess( void );
 

--- a/components/freemodbus/modbus/mb_m.c
+++ b/components/freemodbus/modbus/mb_m.c
@@ -376,6 +376,8 @@ eMBMasterPoll( void )
                 eStatus = peMBMasterFrameSendCur( ucMBMasterGetDestAddress(), ucMBFrame, usMBMasterGetPDUSndLength() );
                 if (eStatus != MB_ENOERR)
                 {
+                    vMBMasterSetErrorType(EV_ERROR_SEND_FRAME);
+                    ( void ) xMBMasterPortEventPost( EV_MASTER_ERROR_PROCESS );
                     ESP_LOGE( MB_PORT_TAG, "%s:Frame send error. %d", __func__, eStatus );
                 } else {
                     ESP_LOG_BUFFER_HEX_LEVEL("POLL SENT buffer", (void*)ucMBFrame, usMBMasterGetPDUSndLength(), ESP_LOG_DEBUG);
@@ -403,6 +405,10 @@ eMBMasterPoll( void )
                         break;
                     case EV_ERROR_EXECUTE_FUNCTION:
                         vMBMasterErrorCBExecuteFunction( ucMBMasterGetDestAddress( ),
+                                ucMBFrame, usMBMasterGetPDUSndLength( ) );
+                        break;
+                    case EV_ERROR_SEND_FRAME:
+                        vMBMasterErrorCBSendFrame( ucMBMasterGetDestAddress( ),
                                 ucMBFrame, usMBMasterGetPDUSndLength( ) );
                         break;
                     case EV_ERROR_OK:

--- a/components/freemodbus/serial_master/modbus_controller/mbc_serial_master.c
+++ b/components/freemodbus/serial_master/modbus_controller/mbc_serial_master.c
@@ -267,6 +267,7 @@ static esp_err_t mbc_serial_master_send_request(mb_param_request_t* request, voi
             break;
 
         case MB_MRE_MASTER_BUSY:
+        case MB_MRE_SEND_FRAME:
             error = ESP_ERR_INVALID_STATE; // Master is busy (previous request is pending)
             break;
 


### PR DESCRIPTION
bugfix: unhandled Modbus error causes stack deadlock

Jira: EQ-1397
- fixed missed error case that leads to Modbus stack deadlock (error was not notified to upper layer).

Signed-off-by: Simon THIEBAUT <simon.thiebaut@zodiac.com>