### PR TITLE
bugfix: missing stack states reset in the case of specific error mana…

### DIFF
--- a/components/freemodbus/modbus/mb_m.c
+++ b/components/freemodbus/modbus/mb_m.c
@@ -391,6 +391,7 @@ eMBMasterPoll( void )
                 /* Execute specified error process callback function. */
                 // Workaround for Espressif issue IDFGH-3829
                 vMBMasterPortTimersDisable();
+                eMBMasterRTUReset();
                 errorType = eMBMasterGetErrorType( );
                 vMBMasterGetPDUSndBuf( &ucMBFrame );
                 switch ( errorType )

--- a/components/freemodbus/modbus/rtu/mbrtu.h
+++ b/components/freemodbus/modbus/rtu/mbrtu.h
@@ -56,6 +56,7 @@ BOOL            xMBRTUTimerT35Expired( void );
 eMBErrorCode    eMBMasterRTUInit( UCHAR ucPort, ULONG ulBaudRate,eMBParity eParity );
 void            eMBMasterRTUStart( void );
 void            eMBMasterRTUStop( void );
+void            eMBMasterRTUReset( void );
 eMBErrorCode    eMBMasterRTUReceive( UCHAR * pucRcvAddress, UCHAR ** pucFrame, USHORT * pusLength );
 eMBErrorCode    eMBMasterRTUSend( UCHAR slaveAddress, const UCHAR * pucFrame, USHORT usLength );
 BOOL            xMBMasterRTUReceiveFSM( void );

--- a/components/freemodbus/modbus/rtu/mbrtu_m.c
+++ b/components/freemodbus/modbus/rtu/mbrtu_m.c
@@ -150,6 +150,17 @@ eMBMasterRTUStop( void )
     EXIT_CRITICAL_SECTION(  );
 }
 
+void
+eMBMasterRTUReset( void )
+{
+    ENTER_CRITICAL_SECTION(  );
+
+    eRcvState = STATE_M_RX_IDLE;
+    eSndState = STATE_M_TX_IDLE;
+
+    EXIT_CRITICAL_SECTION(  );
+}
+
 eMBErrorCode
 eMBMasterRTUReceive( UCHAR * pucRcvAddress, UCHAR ** pucFrame, USHORT * pusLength )
 {


### PR DESCRIPTION
…gement

Jira: EQ-1397
- added reset of stack states variables, that could prevent proper recovery in the case of specific error mangement.

Signed-off-by: Simon THIEBAUT <simon.thiebaut@zodiac.com>